### PR TITLE
wordpress tag 0.1.2 has wrong variables definition for limits

### DIFF
--- a/wordpress/Chart.yaml
+++ b/wordpress/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 name: wordpress
 description: WordPress Configuration
-version: 0.1.2
+version: 0.1.3


### PR DESCRIPTION
is correct in main
so, i created a new branch from main and changed the chart version to
0.1.3