### PR TITLE
Proxysql configmap checksum annotation

### DIFF
--- a/proxysql/Chart.yaml
+++ b/proxysql/Chart.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 name: proxysql
 description: ProxySQL Configuration
-version: 0.1.11
+version: 0.2.0

--- a/proxysql/templates/daemonset.yaml
+++ b/proxysql/templates/daemonset.yaml
@@ -17,6 +17,11 @@ spec:
     metadata:
       labels:
         app: {{ .Values.name }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- range $key, $value := .Values.daemonset.template.annotations }}
+        {{ $key }}: {{ $value }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Values.name }}

--- a/proxysql/values.yaml
+++ b/proxysql/values.yaml
@@ -9,6 +9,8 @@ service:
   type: "NodePort"
   externalTrafficPolicy: "Local"
 daemonset:
+  template:
+    annotations: {}
   containers:
     image: proxysql/proxysql:latest
     imagePullPolicy: "IfNotPresent"


### PR DESCRIPTION
Added annotation of the configmap checksum to the template of the daemonset. Thus, even if the configmap is changed only (e.g. by adding new users), a deployment with the new configuration is triggered.
In addition, the possibility to set more annotations to the daemonset template has been added.